### PR TITLE
refactor(jwt-util): standardize time unit representation for clarity

### DIFF
--- a/poesy-user/src/main/java/cn/d619/poesy/user/util/JwtUtil.java
+++ b/poesy-user/src/main/java/cn/d619/poesy/user/util/JwtUtil.java
@@ -19,7 +19,7 @@ public class JwtUtil {
     @Value("${SECRET_KEY}")
     private String secret;
 
-    private static final long ACCESS_EXPIRATION_TIME = 65 * 1000; // 15 minutes
+    private static final long ACCESS_EXPIRATION_TIME = 15 * 60 * 1000; // 15 minutes
     private static final long REFRESH_EXPIRATION_TIME = 15 * 24 * 60 * 60 * 1000; // 15 days
 
     private Key key;


### PR DESCRIPTION
Replace ad-hoc time unit calculations with a clearer, standardized representation in JwtUtil. The access expiration time has been updated from 65 * 1000 to 15*60*1000